### PR TITLE
poplar: Raise kernel text offset by 64mb

### DIFF
--- a/board/hisilicon/poplar/poplar.c
+++ b/board/hisilicon/poplar/poplar.c
@@ -98,7 +98,7 @@ int dram_init(void)
  * problem as well.
  *
  */
-#define KERNEL_TEXT_OFFSET	0x00080000
+#define KERNEL_TEXT_OFFSET	0x04080000
 
 int dram_init_banksize(void)
 {

--- a/include/configs/poplar.h
+++ b/include/configs/poplar.h
@@ -19,8 +19,8 @@
 
 /* SYS */
 #define CONFIG_SYS_BOOTM_LEN			0x1400000
-#define CONFIG_SYS_INIT_SP_ADDR			0x200000
-#define CONFIG_SYS_LOAD_ADDR			0x800000
+#define CONFIG_SYS_INIT_SP_ADDR			0x04200000
+#define CONFIG_SYS_LOAD_ADDR			0x04800000
 #define CONFIG_SYS_MALLOC_LEN			SZ_32M
 
 /* ATF bl33.bin load address (must match) */


### PR DESCRIPTION
Also change affected defines.
This is to make room for OP-TEE.

Signed-off-by: Victor Chong <victor.chong@linaro.org>